### PR TITLE
Support http response code with no status message

### DIFF
--- a/scapy_http/http.py
+++ b/scapy_http/http.py
@@ -206,7 +206,7 @@ class HTTP(Packet):
             if result:
                 return HTTPRequest
             else:
-                prog = re.compile(r"^HTTP/\d\.\d \d\d\d .+?$")
+                prog = re.compile(r"^HTTP/\d\.\d \d\d\d .*$")
                 result = prog.match(req)
                 if result:
                     return HTTPResponse


### PR DESCRIPTION
Status message on http response is not necessary by RFC https://www.ietf.org/rfc/rfc2616.txt
So If http response with status code but with no message, layer not recognize http response.
My change makes status message not necessary to recognizing http response.