### PR TITLE
porting to python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import shutil
 
 
 def install_into_scapy(a):
-    print 'Installing the HTTP layer extension into Scapy...',
+    print('Installing the HTTP layer extension into Scapy...')
     import scapy
     target_path = os.path.join(
         os.path.dirname(scapy.__file__),
@@ -16,7 +16,7 @@ def install_into_scapy(a):
         'scapy_http/http.py'
     )
     shutil.copy2(source_path, target_path)
-    print 'done!'
+    print('done!')
 
 
 install.sub_commands.append(('install_into_scapy', install_into_scapy))


### PR DESCRIPTION
% sudo pip install scapy-http
Collecting scapy-http
  Downloading scapy-http-1.4.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 20, in <module>
      File "/tmp/pip-build-0eeiw7zq/scapy-http/setup.py", line 8
        print 'Installing the HTTP layer extension into Scapy...',
                                                                ^
    SyntaxError: Missing parentheses in call to 'print'