### PR TITLE
Revert #23

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,8 @@ from setuptools import setup
 from distutils.command.install import install
 import os.path
 import shutil
-import sys
 
 VERSION = '1.8'
-scapy_name = 'scapy-python3' if sys.version_info.major==3 else 'scapy'
 
 
 def install_into_scapy(a):
@@ -30,7 +28,7 @@ setup(
     packages=['scapy_http'],
     version=VERSION,
     description="HTTP-layer support for Scapy",
-    install_requires=[scapy_name],
+    install_requires=['scapy'],
     author=['Luca Invernizzi, Steeve Barbeau'],
     author_email=['invernizzi.l@gmail.com'],
     url='https://github.com/invernizzi/scapy-http',


### PR DESCRIPTION
Reverts https://github.com/invernizzi/scapy-http/pull/23
Explanation: `scapy-python3` is sadly not currently pointing to the official scapy (but instead to scapy3k): it's nowadays an outdated fork that used to be an alternative for scapy with python 3.

Official scapy now supports python 3, so it's no more a good idea to use it (2.4.0 released on 21/03/2018)