### PR TITLE
Rework installation with deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,51 @@
+#! /usr/bin/env python
+
+"""
+scapy-http: HTTP support for Scapy. Deprecated
+"""
+
+from __future__ import print_function
+
+from packaging import version
 from setuptools import setup
-from distutils.command.install import install
+from setuptools.command.install import install
 import os.path
 import shutil
+import warnings
 
 VERSION = '1.8'
 
+DEPRECATION_MESSAGE = """
+Scapy 2.4.3+ has native support for HTTP. It has the same syntax as this package (isn't that nice), plus it packs more features!
 
-def install_into_scapy(a):
-    print('Installing the HTTP layer extension into Scapy...')
-    import scapy
-    target_path = os.path.join(
-        os.path.dirname(scapy.__file__),
-        'layers'
-    )
-    source_path = os.path.join(
-        os.path.dirname(__file__),
-        'scapy_http/http.py'
-    )
-    shutil.copy2(source_path, target_path)
-    print('done!')
+Please consider this package as obsolete - long live Scapy!
+
+DEPRECATED! DEPRECATED! DEPRECATED!
+"""
 
 
-install.sub_commands.append(('install_into_scapy', install_into_scapy))
+class InstallCommand(install):
+    """Installation command"""
+
+    def run(self):
+        import scapy
+        # See README.md
+        warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)  # Soft deprecation
+        if version.parse(scapy.VERSION) >= version.parse("2.4.3"):  # Hard deprecation
+            # Scapy 2.4.3 already has a http.py file in scapy/layers/
+            raise DeprecationWarning("scapy-http cannot be installed on Scapy 2.4.3+ !")
+        print('Installing the HTTP layer extension into Scapy...', end='')
+        target_path = os.path.join(
+            os.path.dirname(scapy.__file__),
+            'layers'
+        )
+        source_path = os.path.join(
+            os.path.dirname(__file__),
+            'scapy_http/http.py'
+        )
+        shutil.copy2(source_path, target_path)
+        print(' OK')
+
 
 setup(
     name="scapy-http",
@@ -33,5 +57,8 @@ setup(
     author_email=['invernizzi.l@gmail.com'],
     url='https://github.com/invernizzi/scapy-http',
     download_url='https://github.com/invernizzi/scapy-http/tarball/' + VERSION,
-    keywords=['http', 'scapy', 'newtork', 'dissect', 'packets']
+    keywords=['http', 'scapy', 'newtork', 'dissect', 'packets'],
+    cmdclass={
+        'install': InstallCommand,
+    },
 )


### PR DESCRIPTION
@invernizzi 
This:
- fixes the `setuptools` installation
- adds a soft deprecation: when trying to install `scapy-http` with Scapy < 2.4.3: do it but display a `DeprecationWarning` (without crashing)
- adds a hard deprecation: when trying to install `scapy-http` witg Scapy >= 2.4.3: raise the error and cancel installation. Otherwise there would be conflicts with Scapy itself.